### PR TITLE
ADDED: Subject Alternate Names support for certs

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,3 +20,9 @@ suites:
     run_list:
       - recipe[ssl_certificate_test::default]
     attributes:
+  - name: subject_alternate_names
+    data_bags_path: "test/kitchen/data_bags"
+    encrypted_data_bag_secret_key_path: "test/kitchen/encrypted_data_bag_secret"
+    run_list:
+      - recipe[ssl_certificate_test::subject_alternate_names]
+    attributes:

--- a/README.md
+++ b/README.md
@@ -223,6 +223,11 @@ By default the resource will create a self-signed certificate, but a custom one 
     <td>SSL cert file content in clear.</td>
     <td><em>calculated</em></td>
   </tr>
+  <tr>
+    <td>subject_alternate_names</td>
+    <td>Subject Alternate Names for the cert.</td>
+    <td><code>nil</code></td>
+  </tr>
 </table>
 
 Templates
@@ -396,6 +401,10 @@ When a namespace is set in the resource, it will try to read the following attri
   <tr>
     <td><code>namespace["ssl_cert"]["content"]</code></td>
     <td>SSL cert content used when reading from attributes.</td>
+  </tr>
+  <tr>
+    <td><code>namespace["ssl_cert"]["subject_alternate_names"]</code></td>
+    <td>An array of Subject Alternate Names for the SSL cert. Needed if your site has multiple domain names on the same cert.</td>
   </tr>
 </table>
 
@@ -665,6 +674,21 @@ node.default["mysite"]["ssl_cert"]["encrypted"] = false
 ssl_certificate "mysite" do
   namespace node["mysite"]
 end
+```
+
+### Creating a Cert with Subject Alternate Names
+
+```ruby
+domain = 'mysite.com'
+# SAN for mysite.com, foo.mysite.com, bar.mysite.com, www.mysite.com
+node.default[ domain ]['ssl_cert']['subject_alternate_names'] = [ domain, 'foo.'+domain, 'bar.'+domain, 'www.' + domain ]
+
+ssl_certificate 'mysite.com' do
+  namespace node[ domain ]
+  key_source 'self-signed'
+  cert_source 'self-signed'
+end
+
 ```
 
 Testing

--- a/test/integration/subject_alternate_names/bats/certificates_content_test.bats
+++ b/test/integration/subject_alternate_names/bats/certificates_content_test.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+CERT_PATH="/etc/"
+DEB_PATH="/etc/ssl/"
+RH_PATH="/etc/pki/tls/"
+
+setup() {
+    if [ -d $DEB_PATH ]; then
+        CERT_PATH=$DEB_PATH
+    elif [ -d $RH_PATH ]; then
+        CERT_PATH=$RH_PATH
+    fi
+    GREP_COMMAND1="openssl x509 -in ${CERT_PATH}certs/subject_alternate_names.pem -text -noout | grep"
+    GREP_COMMAND2="openssl x509 -in ${CERT_PATH}certs/subject_alternate_names2.pem -text -noout | grep"
+}
+
+@test "the non-SAN certificate has no Subject Alternative Name line" {
+    run bash -c "$GREP_COMMAND1 'X509v3 Subject Alternative Name'"
+    [ "$status" -eq 1 ]
+}
+
+@test "the SAN certificate has a Subject Alternative Name line" {
+    run bash -c "$GREP_COMMAND2 'X509v3 Subject Alternative Name'"
+    [ "$status" -eq 0 ]
+}
+
+@test "the SAN certificate has a DNS:foo entry" {
+    run bash -c "$GREP_COMMAND2 DNS:foo"
+    [ "$status" -eq 0 ]
+}
+
+@test "the SAN certificate has a DNS:bar entry" {
+    run bash -c "$GREP_COMMAND2 DNS:foo"
+    [ "$status" -eq 0 ]
+}
+
+@test "the SAN certificate has a DNS:subject-alternate-name entry" {
+    run bash -c "$GREP_COMMAND2 DNS:subject-alternate-name"
+    [ "$status" -eq 0 ]
+}
+
+@test "the SAN certificate has a DNS:foo.subject-alternate-name entry" {
+    run bash -c "$GREP_COMMAND2 DNS:foo.subject-alternate-name"
+    [ "$status" -eq 0 ]
+}

--- a/test/integration/subject_alternate_names/bats/certificates_exist_test.bats
+++ b/test/integration/subject_alternate_names/bats/certificates_exist_test.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+CERT_PATH="/etc/"
+DEB_PATH="/etc/ssl/"
+RH_PATH="/etc/pki/tls/"
+
+setup() {
+	if [ -d $DEB_PATH ]; then
+		CERT_PATH=$DEB_PATH
+	elif [ -d $RH_PATH ]; then
+		CERT_PATH=$RH_PATH
+	fi
+}
+
+@test "the certificates exist" {
+	[ -f "${CERT_PATH}certs/subject_alternate_names.pem" -a -f "${CERT_PATH}certs/subject_alternate_names2.pem" ]
+}

--- a/test/kitchen/cookbooks/ssl_certificate_test/recipes/subject_alternate_names.rb
+++ b/test/kitchen/cookbooks/ssl_certificate_test/recipes/subject_alternate_names.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook Name:: ssl_certificate_test
+# Recipe:: subject_alternate_names
+#
+# Copyright 2014, Onddo Labs, Sl.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ssl_certificate 'subject_alternate_names' do
+  key_source 'self-signed'
+  cert_source 'self-signed'
+end
+
+domain = node['fqdn']
+node.default[ domain ]['ssl_cert']['subject_alternate_names'] = [ domain, 'foo', 'bar', 'foo.' + domain ]
+
+ssl_certificate 'subject_alternate_names2' do
+  namespace node[ domain ]
+  key_source 'self-signed'
+  cert_source 'self-signed'
+end


### PR DESCRIPTION
Hi! I've been using your awesome cookbook lately, but for some of my servers, I needed to be able to have Subject Alternate Names support in my certs. Rather than asking you to add it, I figured it would be a good way to get better at Chef to add the feature myself. I'm submitting the PR to you in case you'd like to add it back into your cookbook.

Thanks!

It is now possible to create certs that support multiple DNS names.

ADDED: Tests for Subject Alternative Name feature
UPDATED: README.md now includes documentation for the SAN feature
