### PR TITLE
Fixed Directory Permissions for Apache 2.4

### DIFF
--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -12,7 +12,7 @@
   <Directory <%= @params[:docroot] %>>
     Options <%= [@params[:directory_options] || 'FollowSymLinks' ].flatten.join ' ' %>
     AllowOverride <%= [@params[:allow_override] || 'None' ].flatten.join ' ' %>
-    <% if node['apache']['version'].to_f >= '2.4' -%>
+    <% if node['apache']['version'].to_f >= 2.4 -%>
     Require all granted
     <% else -%>
     Order allow,deny
@@ -22,7 +22,7 @@
 
   <Directory />
     Options FollowSymLinks
-    <% if node['apache']['version'].to_f >= '2.4' -%>
+    <% if node['apache']['version'].to_f >= 2.4 -%>
     Require all denied
     <% else -%>
     Allow from none


### PR DESCRIPTION
Apache 2.4 directory permissions no longer support 'Allow from all'.
Instead they use the 'Require all granted' syntax.  I have added in
a check for apache 2.4 in the directory that makes this change.
