### PR TITLE
Add default attributes to support windows

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,12 +19,20 @@
 # limitations under the License.
 #
 
-default['ssl_certificate']['user'] = 'root'
+case node['platform']
+when 'windows'
+  default['ssl_certificate']['user'] = 'SYSTEM'
+else
+  default['ssl_certificate']['user'] = 'root'
+end
+
 default['ssl_certificate']['items'] = []
 
 case node['platform']
 when 'openbsd', 'freebsd', 'mac_os_x'
   default['ssl_certificate']['group'] = 'wheel'
+when 'windows'
+  default['ssl_certificate']['group'] = 'Administrators'
 else
   default['ssl_certificate']['group'] = 'root'
 end
@@ -39,6 +47,9 @@ when 'redhat', 'centos', 'fedora', 'scientific', 'amazon'
 when 'openbsd', 'freebsd', 'mac_os_x'
   default['ssl_certificate']['key_dir'] = '/etc/ssl'
   default['ssl_certificate']['cert_dir'] = '/etc/ssl'
+when 'windows'
+  default['ssl_certificate']['key_dir'] = Chef::Config[:file_cache_path]
+  default['ssl_certificate']['cert_dir'] = Chef::Config[:file_cache_path]
 else
   default['ssl_certificate']['key_dir'] = '/etc'
   default['ssl_certificate']['cert_dir'] = '/etc'


### PR DESCRIPTION
Hello,

I recently tested this cookbook on windows, it worked great once I fixed the `key_dir` and `cert_dir` attributes.
To be cleaner, I also provide standard default values for `user` and `group`.

Regarding the tests ... it's a bit hard for me to complete them, because I first need a public windows box for kitchen, then existing test recipes are combined with either apache2 or nginx.

I'm open to feedback, so let me know if you want more documentation/test, etc.

cc. @aboten