### PR TITLE
Add support for ssl_certificate using CA with a passphrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ By default the resource will create a self-signed certificate, but a custom one 
 | chain_combined_path     | *calculated*                   | Intermediate certificate chain combined file full path (for **nginx**).
 | ca_cert_path            | *nil*                          | Certificate Authority full path.
 | ca_key_path             | *nil*                          | Key Authority full path.
+| ca_key_passphrase       | *nil*                          | Key Authority passphrase.
 | pkcs12_path             | *nil*                          | Optional PKCS12 full path.
 | pkcs12_passphrase       | *nil*                          | Optional PKCS12 passphrase.
 
@@ -812,6 +813,7 @@ cert = ssl_certificate 'test' do
   cert_source 'with_ca'
   ca_cert_path ca_cert
   ca_key_path ca_key
+  ca_key_passphrase ca_key_passphrase
 end
 ```
 

--- a/libraries/resource_ssl_certificate_cert.rb
+++ b/libraries/resource_ssl_certificate_cert.rb
@@ -48,6 +48,7 @@ class Chef
             subject_alternate_names
             ca_cert_path
             ca_key_path
+            ca_key_passphrase
           )
         end
 
@@ -120,6 +121,10 @@ class Chef
 
         def ca_key_path(arg = nil)
           set_or_return(:ca_key_path, arg, kind_of: String)
+        end
+
+        def ca_key_passphrase(arg = nil)
+          set_or_return(:ca_key_passphrase, arg, kind_of: String)
         end
 
         protected
@@ -232,7 +237,8 @@ class Chef
             "Generating new certificate: #{name} from the given CA."
           )
           content = generate_cert(
-            key_content, cert_subject, time, ca_cert_content, ca_key_content
+            key_content, cert_subject, time, ca_cert_content, ca_key_content,
+            ca_key_passphrase
           )
           updated_by_last_action(true)
           content
@@ -268,6 +274,10 @@ class Chef
 
         def default_ca_key_path
           lazy { read_namespace(%w(ca_key_path)) }
+        end
+
+        def default_ca_key_passphrase
+          lazy { read_namespace(%w(ca_key_passphrase)) }
         end
       end
     end

--- a/test/cookbooks/ssl_certificate_test/libraries/cert_ca_helper.rb
+++ b/test/cookbooks/ssl_certificate_test/libraries/cert_ca_helper.rb
@@ -34,20 +34,13 @@ module CACertificate
     ]
   end
 
-  def self.key_with_pass_phrase(key, pass_phrase)
-    cipher = OpenSSL::Cipher::Cipher.new('AES-128-CBC')
-
-    open(key_file, 'w', 0400) do |io|
-      io.write key.export(cipher, pass_phrase)
-    end
-  end
-
   def self.key_to_file(key_file, pass_phrase = nil)
     key = OpenSSL::PKey::RSA.new(2048)
-    if pass_phrase
-      key_with_pass_phrase(key, pass_phrase)
-    else
-      open(key_file, 'w', 0400) do |io|
+    open(key_file, 'w', 0400) do |io|
+      if pass_phrase
+        cipher = OpenSSL::Cipher::Cipher.new('AES-128-CBC')
+        io.write key.export(cipher, pass_phrase)
+      else
         io.write key.to_pem
       end
     end
@@ -69,9 +62,9 @@ module CACertificate
     cert
   end
 
-  def self.ca_cert_to_file(subject, key_file, cert_file, time)
+  def self.ca_cert_to_file(subject, key_file, cert_file, time, key_pass = nil)
     key = File.read(key_file)
-    key, cert = generate_generic_x509_key_cert(key, time)
+    key, cert = generate_generic_x509_key_cert(key, time, key_pass)
 
     generate_self_signed_ca_cert(key, cert, subject)
 

--- a/test/cookbooks/ssl_certificate_test/recipes/self_signed_with_ca_certificate.rb
+++ b/test/cookbooks/ssl_certificate_test/recipes/self_signed_with_ca_certificate.rb
@@ -69,6 +69,35 @@ web_app 'test.com' do
   extra_directives EnableSendfile: 'On'
 end
 
+# Create a certificate from a secured CA
+
+sec_ca_cert = ::File.join(node['ssl_certificate']['cert_dir'], 'sec_CA.crt')
+sec_ca_key = ::File.join(node['ssl_certificate']['key_dir'], 'sec_CA.key')
+sec_ca_pwd = 'mySecretPassPhrase'
+sec_ca_info = {
+  'common_name' => 'ca.secure.com',
+  'country' => 'FR',
+  'city' => 'Paris',
+  'state' => 'Ile de Paris',
+  'organization' => 'Toto',
+  'department' => 'Titi',
+  'email' => 'titi@secure.com',
+  'time' => 10 * 365,
+}
+
+::CACertificate.key_to_file(sec_ca_key, sec_ca_pwd)
+::CACertificate.ca_cert_to_file(
+  sec_ca_info, sec_ca_key, sec_ca_cert, sec_ca_info['time'], sec_ca_pwd
+)
+
+ssl_certificate 'secured.test.com' do
+  namespace node['test.com']
+  common_name 'secured.test.com'
+  ca_cert_path sec_ca_cert
+  ca_key_path sec_ca_key
+  ca_key_passphrase sec_ca_pwd
+end
+
 # Create the CA from an encrypted data bag
 
 ca_cert2 = ssl_certificate 'ca.example.org' do

--- a/test/cookbooks/ssl_certificate_test/recipes/self_signed_with_ca_certificate.rb
+++ b/test/cookbooks/ssl_certificate_test/recipes/self_signed_with_ca_certificate.rb
@@ -33,8 +33,6 @@ node.default['test.com']['department'] = 'Titi'
 node.default['test.com']['email'] = 'titi@test.com'
 node.default['test.com']['ssl_key']['source'] = 'self-signed'
 node.default['test.com']['ssl_cert']['source'] = 'with_ca'
-node.default['test.com']['ca_cert_path'] = ca_cert
-node.default['test.com']['ca_cert_key'] = ca_key
 
 node.default['ca-certificate']['common_name'] = 'ca.test.com'
 node.default['ca-certificate']['country'] = 'FR'

--- a/test/integration/with_ca/bats/with_ca_certificates.bats
+++ b/test/integration/with_ca/bats/with_ca_certificates.bats
@@ -54,6 +54,24 @@ setup() {
   openssl rsa -in "${KEY_PATH}/test.com.key" -text -noout
 }
 
+@test "creates a certificate with a secured CA" {
+  [ -f "${CERT_PATH}/secured.test.com.pem" ]
+}
+
+@test "the certificate with a secured CA has the correct issuer" {
+  openssl x509 -in "${CERT_PATH}/secured.test.com.pem" -noout -text \
+    | grep -F 'Issuer: C=FR, ST=Ile de Paris, L=Paris, O=Toto, OU=Titi, CN=ca.secure.com/emailAddress=titi@secure.com'
+}
+
+@test "the certificate with a CA has the correct subject" {
+  openssl x509 -in "${CERT_PATH}/secured.test.com.pem" -noout -text \
+    | grep -F 'Subject: C=FR, ST=Ile de Paris, L=Paris, O=Toto, OU=Titi, CN=secured.test.com/emailAddress=titi@test.com'
+}
+
+@test "creates the certificate key with a secured CA" {
+  openssl rsa -in "${KEY_PATH}/secured.test.com.key" -text -noout
+}
+
 @test "creates a CA certificate from a data bag" {
   [ -f "${CERT_PATH}/ca.example.org.pem" ]
 }

--- a/test/integration/with_ca/serverspec/with_ca_certificates_spec.rb
+++ b/test/integration/with_ca/serverspec/with_ca_certificates_spec.rb
@@ -47,6 +47,20 @@ describe file("#{cert_dir}/test.com.pem") do
   it { should be_grouped_into group }
 end
 
+describe file("#{key_dir}/secured.test.com.key") do
+  it { should be_file }
+  it { should be_mode 600 }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into group }
+end
+
+describe file("#{cert_dir}/secured.test.com.pem") do
+  it { should be_file }
+  it { should be_mode 644 }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into group }
+end
+
 describe file("#{key_dir}/example.org.key") do
   it { should be_file }
   it { should be_mode 600 }

--- a/test/unit/recipes/self_signed_with_ca_certificate_spec.rb
+++ b/test/unit/recipes/self_signed_with_ca_certificate_spec.rb
@@ -183,6 +183,24 @@ describe 'ssl_certificate_test::self_signed_with_ca_certificate',
         .with_sensitive(true)
     end
 
+    it 'creates secured.test.com key' do
+      expect(chef_run).to create_file('test.com SSL certificate key')
+        .with_path(::File.join(key_dir, 'secured.test.com.key'))
+        .with_owner('root')
+        .with_group('root')
+        .with_mode(00600)
+        .with_sensitive(true)
+    end
+
+    it 'creates test.com certificate' do
+      expect(chef_run).to create_file('secured.test.com SSL public certificate')
+        .with_path(::File.join(cert_dir, 'secured.test.com.pem'))
+        .with_owner('root')
+        .with_group('root')
+        .with_mode(00644)
+        .with_sensitive(true)
+    end
+
     it 'creates ca.example.org CA certificate key' do
       expect(chef_run).to create_file('ca.example.org SSL certificate key')
         .with_path(::File.join(key_dir, 'ca.example.org.key'))


### PR DESCRIPTION
Hello,

This PR aim to had support of Certificate Authority with passphrase to the `ssl_certificate`.
This is a basic implementation, with plain text pass phrase passed as attribute `ca_key_passphrase`.

I tried to add useful tests and a bit of documentation, but let me know if you want me to add more.

cc. @aboten