### PR TITLE
Allow to generate pkcs12 containing cert and private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ By default the resource will create a self-signed certificate, but a custom one 
 | chain_combined_path     | *calculated*                   | Intermediate certificate chain combined file full path (for **nginx**).
 | ca_cert_path            | *nil*                          | Certificate Authority full path.
 | ca_key_path             | *nil*                          | Key Authority full path.
+| pkcs12_path             | *nil*                          | Optional PKCS12 full path.
+| pkcs12_passphrase       | *nil*                          | Optional PKCS12 passphrase.
 
 Templates
 =========
@@ -407,6 +409,8 @@ When a namespace is set in the resource, it will try to read the following attri
 | `namespace['ssl_chain']['content']`                | Intermediate certificate chain content used when reading from attributes.
 | `namespace['ca_cert_path']`                        | Certificate Authority full path.
 | `namespace['ca_key_path']`                         | Key Authority full path.
+| `namespace['pkcs12_path']`                         | Optional PKCS12 full path.
+| `namespace['pkcs12_passphrase']`                   | Optional PKCS12 passphrase.
 
 ## Examples
 
@@ -781,6 +785,18 @@ node.default[cert_name]['ssl_chain']['item_key'] = 'content'
 
 ssl_certificate 'chain-data-bag' do
   namespace cert_name
+end
+```
+### Creating a PKCS12 containing both Certificate and private Key
+
+```ruby
+ssl_certificate 'mysite' do
+  common_name 'cloud.mysite.com'
+  source 'self-signed'
+  key_path '/etc/key/my.key'
+  cert_path '/etc/cert/my.pem'
+  pkcs12_path '/home/me/my.p12'
+  pkcs12_passphrase 'I_Want_To_Secure_My_P12'
 end
 ```
 

--- a/libraries/provider_ssl_certificate.rb
+++ b/libraries/provider_ssl_certificate.rb
@@ -80,6 +80,22 @@ class Chef
         )
       end
 
+      def create_pkcs12?
+        current_p12 = @current_resource.pkcs12
+        new_p12 = new_resource.pkcs12
+
+        current_p12.nil? ||
+          new_p12.key.to_s != current_p12.key.to_s ||
+          new_p12.certificate.to_s != current_p12.certificate.to_s
+      end
+
+      def create_pkcs12
+        file_create(
+          'SSL public PKCS12',
+          new_resource.pkcs12_path, new_resource.pkcs12.to_der
+        )
+      end
+
       def create_chain?
         !new_resource.chain_name.nil? && !new_resource.chain_content.nil?
       end
@@ -112,6 +128,7 @@ class Chef
         return if current_resource_updated?(new_resource_updated)
         create_key
         create_cert
+        create_pkcs12 if new_resource.pkcs12_path && create_pkcs12?
         create_chain_combined
         create_chain if create_chain?
       end

--- a/libraries/resource_ssl_certificate.rb
+++ b/libraries/resource_ssl_certificate.rb
@@ -31,6 +31,7 @@ require_relative 'resource_ssl_certificate_keycert'
 require_relative 'resource_ssl_certificate_chain'
 require_relative 'resource_ssl_certificate_generators'
 require_relative 'resource_ssl_certificate_readers'
+require_relative 'resource_ssl_certificate_pkcs12'
 
 # Chef configuration management tool main class.
 class Chef
@@ -53,6 +54,8 @@ class Chef
       include ::Chef::Resource::SslCertificate::Generators
       # Include helper methods to read from differente sources.
       include ::Chef::Resource::SslCertificate::Readers
+      # Include methods related to PKCS12 attributes.
+      include ::Chef::Resource::SslCertificate::PKCS12
 
       def initialize(name, run_context = nil)
         super

--- a/libraries/resource_ssl_certificate_pkcs12.rb
+++ b/libraries/resource_ssl_certificate_pkcs12.rb
@@ -1,0 +1,81 @@
+# encoding: UTF-8
+#
+# Cookbook Name:: ssl_certificate
+# Library:: resource_ssl_certificate_pkcs12
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+# Copyright:: Copyright (c) 2015 Criteo
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource'
+
+# Chef configuration management tool main class.
+class Chef
+  # Chef Resource describes the desired state of an element of your
+  # infrastructure.
+  class Resource
+    class SslCertificate < Chef::Resource
+      # ssl_certificate Chef Resource PKCS12 related methods.
+      module PKCS12
+        # Resource key attributes to be initialized by a `default_#{attribute}`
+        # method.
+        unless defined?(::Chef::Resource::SslCertificate::PKCS12::ATTRS)
+          ATTRS = %w(
+            pkcs12_path
+            pkcs12_passphrase
+          )
+        end
+
+        public
+
+        def initialize_pkcs12_defaults
+          initialize_attribute_defaults(PKCS12::ATTRS)
+        end
+
+        # PKCS12 public methods
+
+        def generate_pkcs12(name, key_content, cert_content,
+          pkcs12_passphrase = nil, key_passphrase = nil)
+          key = OpenSSL::PKey.read key_content, key_passphrase
+          crt = OpenSSL::X509::Certificate.new cert_content
+          OpenSSL::PKCS12.create(pkcs12_passphrase, name, key, crt)
+        end
+
+        def pkcs12
+          @pkcs12 ||= generate_pkcs12 name, key_content, cert_content,
+                                      pkcs12_passphrase
+        end
+
+        def pkcs12_path(arg = nil)
+          set_or_return(:pkcs12_path, arg, kind_of: String)
+        end
+
+        def pkcs12_passphrase(arg = nil)
+          set_or_return(:pkcs12_passphrase, arg, kind_of: String)
+        end
+
+        protected
+
+        def default_pkcs12_path
+          lazy { read_namespace(%w(pkcs12_path)) }
+        end
+
+        def default_pkcs12_passphrase
+          lazy { read_namespace(%w(pkcs12_passphrase)) }
+        end
+      end
+    end
+  end
+end

--- a/test/cookbooks/ssl_certificate_test/recipes/default.rb
+++ b/test/cookbooks/ssl_certificate_test/recipes/default.rb
@@ -116,6 +116,12 @@ ssl_certificate cert7_name do
   namespace node[cert7_name]
 end
 
+p12_path = ::File.join node['ssl_certificate']['cert_dir'], 'dummy8.p12'
+ssl_certificate 'dummy8' do
+  source 'self-signed'
+  pkcs12_path p12_path
+end
+
 # Apache2 test
 
 node.default[node['fqdn']]['organization'] =

--- a/test/integration/default/bats/certificates.bats
+++ b/test/integration/default/bats/certificates.bats
@@ -86,3 +86,15 @@ setup() {
 @test "creates dummy6 certificate key from node attributes" {
   openssl rsa -in "${KEY_PATH}/dummy6-attributes.key" -text -noout
 }
+
+@test "creates dummy8 certificate" {
+  openssl x509 -in "${CERT_PATH}/dummy8.pem" -text -noout
+}
+
+@test "creates dummy8 certificate key" {
+  openssl rsa -in "${KEY_PATH}/dummy8.key" -text -noout
+}
+
+@test "creates dummy8 PKCS12 file" {
+  openssl pkcs12 -in "${CERT_PATH}/dummy8.p12" -noout -passin pass:
+}

--- a/test/integration/default/serverspec/certificates_spec.rb
+++ b/test/integration/default/serverspec/certificates_spec.rb
@@ -91,3 +91,24 @@ describe file("#{cert_dir}/dummy6-attributes.pem") do
   it { should be_owned_by 'root' }
   it { should be_grouped_into group }
 end
+
+describe file("#{key_dir}/dummy8.key") do
+  it { should be_file }
+  it { should be_mode 600 }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into group }
+end
+
+describe file("#{cert_dir}/dummy8.pem") do
+  it { should be_file }
+  it { should be_mode 644 }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into group }
+end
+
+describe file("#{cert_dir}/dummy8.p12") do
+  it { should be_file }
+  it { should be_mode 644 }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into group }
+end


### PR DESCRIPTION
Hello,

This is a small PR to allow generation of a p12 file containing both certificate and private key.
Again I tried to add useful tests and a bit of documentation, but let me know if you want me to add more.

@zuazo  this one should already follow rubocop normally :)

cc. @aboten