### PR TITLE
Pfx on windows fails due to CRLF conversion

### DIFF
--- a/libraries/resource_ssl_certificate_readers.rb
+++ b/libraries/resource_ssl_certificate_readers.rb
@@ -69,7 +69,7 @@ class Chef
 
         def read_from_path(path)
           return nil unless ::File.exist?(path)
-          ::IO.read(path)
+          File.open(path, 'rb') { |io| io.read }
         end
 
         def safe_read_from_path(desc, path)

--- a/libraries/resource_ssl_certificate_readers.rb
+++ b/libraries/resource_ssl_certificate_readers.rb
@@ -69,7 +69,7 @@ class Chef
 
         def read_from_path(path)
           return nil unless ::File.exist?(path)
-          File.open(path, 'rb') { |io| io.read }
+          ::File.open(path, 'rb') { |io| io.read }
         end
 
         def safe_read_from_path(desc, path)

--- a/test/cookbooks/ssl_certificate_test/libraries/cert_ca_helper.rb
+++ b/test/cookbooks/ssl_certificate_test/libraries/cert_ca_helper.rb
@@ -70,7 +70,8 @@ module CACertificate
   end
 
   def self.ca_cert_to_file(subject, key_file, cert_file, time)
-    key = File.read(key_file)
+    key = File.open(key_file, 'rb') { |io| io.read }
+
     key, cert = generate_generic_x509_key_cert(key, time)
 
     generate_self_signed_ca_cert(key, cert, subject)


### PR DESCRIPTION
Read certificates in way that CRLF conversion will not occur.