### PR TITLE
Fix sending notifications from the ssl_certificate resource

### DIFF
--- a/libraries/provider_ssl_certificate.rb
+++ b/libraries/provider_ssl_certificate.rb
@@ -62,7 +62,8 @@ class Chef
         end
         run_context.resource_collection << resource
         resource.run_action(:create)
-        new_resource.updated_by_last_action(resource.updated_by_last_action?)
+        return resource unless resource.updated_by_last_action?
+        new_resource.updated_by_last_action(true)
         resource
       end
 


### PR DESCRIPTION
Currently, the "updated" status of the ssl_certificate resource is determined by
the very last internal file resource from the provider that gets processed.
However, we want the ssl_certificate resource to send a notification if *any* of
the internal file resources updates, not just the last one.