### PR TITLE
Remove the internal file resources from the resource collection

### DIFF
--- a/libraries/provider_ssl_certificate.rb
+++ b/libraries/provider_ssl_certificate.rb
@@ -60,7 +60,6 @@ class Chef
           content f_content
           mode f_mode
         end
-        run_context.resource_collection << resource
         resource.run_action(:create)
         new_resource.updated_by_last_action(resource.updated_by_last_action?)
         resource


### PR DESCRIPTION
This doesn't appear to do anything except create "dummy" file resources (with
`action :nothing`) on the stack.