### PR TITLE
Only add internal file resources to the collection when running tests

### DIFF
--- a/libraries/provider_ssl_certificate.rb
+++ b/libraries/provider_ssl_certificate.rb
@@ -60,7 +60,7 @@ class Chef
           content f_content
           mode f_mode
         end
-        run_context.resource_collection << resource
+        run_context.resource_collection << resource if defined?(ChefSpec)
         resource.run_action(:create)
         new_resource.updated_by_last_action(resource.updated_by_last_action?)
         resource


### PR DESCRIPTION
During a "normal" Chef run, adding these resources to the context's resource
collection just creates "dummy" file resources (with `action :nothing`) to the
stack, so only add them when running tests.