### PR TITLE
Feature/vault fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,10 @@ ssl_certificate 'mysite' do
 end
 ```
 
+For testing you can enabled fall back to use unencrypted data bags if chef
+vault is not found by setting attribute ['chef-vault']['databag_fallback'] to
+true value
+
 ### Reading the Certificate from Files
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ end
 ```
 
 For testing you can enabled fall back to use unencrypted data bags if chef
-vault is not found by setting attribute ['chef-vault']['databag_fallback'] to
+vault is not found by setting attribute `['chef-vault']['databag_fallback']` to
 true value
 
 ### Reading the Certificate from Files

--- a/libraries/resource_ssl_certificate_readers.rb
+++ b/libraries/resource_ssl_certificate_readers.rb
@@ -112,7 +112,13 @@ class Chef
         def read_from_chef_vault(bag, item, key)
           require 'chef-vault'
           unsafe_no_exceptions_block do
-            data = ChefVault::Item.load(bag, item)
+            data = if ChefVault::Item.vault?(bag, item)
+                     ChefVault::Item.load(bag, item)
+                   elsif node['chef-vault']['databag_fallback']
+                     Chef::DataBagItem.load(bag, item)
+                   else
+                     raise "Trying to load a regular data bag item #{id} from #{bag}, and databag_fallback is disabled"
+                   end
             data[key.to_s]
           end
         end

--- a/libraries/resource_ssl_certificate_readers.rb
+++ b/libraries/resource_ssl_certificate_readers.rb
@@ -117,7 +117,7 @@ class Chef
                    elsif node['chef-vault']['databag_fallback']
                      Chef::DataBagItem.load(bag, item)
                    else
-                     raise "Trying to load a regular data bag item #{id} from #{bag}, and databag_fallback is disabled"
+                     raise "Trying to load a regular data bag item #{item} from #{bag}, and databag_fallback is disabled"
                    end
             data[key.to_s]
           end

--- a/metadata.rb
+++ b/metadata.rb
@@ -115,3 +115,11 @@ attribute 'ssl_certificate/service/use_stapling',
           type: 'string',
           required: 'optional',
           calculated: true
+
+attribute 'chef-vault/databag_fallback',
+          display_name: 'fallback to unencrypted data bags',
+          description: 'Whether to fallback to unencrypted data bag if'\
+                       ' chef-vault not found.',
+          type: 'string',
+          required: 'optional',
+          default: 'false'


### PR DESCRIPTION
Copied code from [chef_vault_item helper](https://github.com/chef-cookbooks/chef-vault/blob/6ad7e34f9b860dc1b339a0c1814214595098e4b0/libraries/helpers.rb#L35)  to fallback to unencrypted data_bag source if `node['chef-vault']['databag_fallback']` is set to simplify testing in Test Kitchen.