### PR TITLE
custom mode for key file

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ When a namespace is set in the resource, it will try to read the following attri
 | `namespace['secret_file']`                         | Attribute for setting certificate chef secret file and key chef secret file (both) to a value (`key_secret_file` and `cert_secret_file`).
 | `namespace['ssl_key']['source']`                   | Source type to get the SSL key from. Can be `'self-signed'`, `'attribute'`, `'data-bag'`, `'chef-vault'` or `'file'`.
 | `namespace['ssl_key']['path']`                     | File path of the SSL key.
+| `namespace['ssl_key']['mode']`                     | File mode of the SSL key.
 | `namespace['ssl_key']['bag']`                      | Name of the Data Bag where the SSL key is stored.
 | `namespace['ssl_key']['item']`                     | Name of the Data Bag Item where the SSL key is stored.
 | `namespace['ssl_key']['item_key']`                 | Key of the Data Bag Item where the SSL key is stored.
@@ -210,6 +211,7 @@ my_cert_path = '/etc/certs/my-webapp.pem'
 # know the paths
 ssl_certificate 'my-webapp' do
   key_path my_key_path
+  key_mode 00640
   cert_path my_cert_path
 end
 
@@ -743,6 +745,7 @@ By default the resource will create a self-signed certificate, but a custom one 
 | encrypted               | `nil`                          | Write only attribute for setting certificate encryption and key encryption (both) to a value (`key_encrypted` and `cert_encrypted`).
 | secret_file             | `nil`                          | Write only attribute for setting certificate chef secret file and key chef secret file (both) to a value (`key_secret_file` and `cert_secret_file`).
 | key_path                | *calculated*                   | Private key full path.
+| key_mode                | `0600`                         | Private key file mode.
 | key_name                | `"#{name}.key"`                | Private key file name.
 | key_dir                 | *calculated*                   | Private key directory path.
 | key_source              | `'self-signed'`                | Source type to get the SSL key from. Can be `'self-signed'`, `'attribute'`, `'data-bag'`, `'chef-vault'` or `'file'`.

--- a/libraries/provider_ssl_certificate.rb
+++ b/libraries/provider_ssl_certificate.rb
@@ -70,7 +70,7 @@ class Chef
       def create_key
         file_create(
           'SSL certificate key',
-          new_resource.key_path, new_resource.key_content, 00600
+          new_resource.key_path, new_resource.key_content, new_resource.key_mode
         )
       end
 

--- a/libraries/resource_ssl_certificate_key.rb
+++ b/libraries/resource_ssl_certificate_key.rb
@@ -37,6 +37,7 @@ class Chef
             key_name
             key_dir
             key_path
+            key_mode
             key_source
             key_bag
             key_item
@@ -73,6 +74,10 @@ class Chef
 
         def key_path(arg = nil)
           set_or_return(:key_path, arg, kind_of: String, required: true)
+        end
+
+        def key_mode(arg = nil)
+          set_or_return(:key_mode, arg, kind_of: Integer)
         end
 
         def key_source(arg = nil)
@@ -116,6 +121,12 @@ class Chef
         def default_key_path
           lazy_cached_variable(:default_key_path) do
             read_namespace(%w(ssl_key path)) || ::File.join(key_dir, key_name)
+          end
+        end
+
+        def default_key_mode
+          lazy do
+            read_namespace(%w(ssl_key mode)) || read_namespace('mode') || 00600
           end
         end
 


### PR DESCRIPTION
Adds option to set permissions for certificate private key file, e.g. make it group readable for `ssl-cert` group on Debian systems or group readable for `mysql` user.