### PR TITLE
Adds certificate chain to PKCS12 file

### DIFF
--- a/libraries/resource_ssl_certificate_pkcs12.rb
+++ b/libraries/resource_ssl_certificate_pkcs12.rb
@@ -56,8 +56,11 @@ class Chef
         def generate_pkcs12
           key = OpenSSL::PKey.read(key_content)
           crt = OpenSSL::X509::Certificate.new(cert_content)
-          chain = chain_content ? [crt, OpenSSL::X509::Certificate.new(chain_content)] : nil
-          OpenSSL::PKCS12.create(pkcs12_passphrase, name, key, crt, chain).to_der
+          chain = if chain_content
+                    [crt, OpenSSL::X509::Certificate.new(chain_content)]
+                  end
+          OpenSSL::PKCS12.create(pkcs12_passphrase,
+                                 name, key, crt, chain).to_der
         end
 
         def pkcs12_content

--- a/libraries/resource_ssl_certificate_pkcs12.rb
+++ b/libraries/resource_ssl_certificate_pkcs12.rb
@@ -56,7 +56,8 @@ class Chef
         def generate_pkcs12
           key = OpenSSL::PKey.read(key_content)
           crt = OpenSSL::X509::Certificate.new(cert_content)
-          OpenSSL::PKCS12.create(pkcs12_passphrase, name, key, crt).to_der
+          chain = chain_content ? [crt, OpenSSL::X509::Certificate.new(chain_content)] : nil
+          OpenSSL::PKCS12.create(pkcs12_passphrase, name, key, crt, chain).to_der
         end
 
         def pkcs12_content


### PR DESCRIPTION
Most java applications require both the certificate and the intermediate
chain to be part of the keystore; this adds the intermediate certificate
chain to support these apps.