### PR TITLE
Add self-signed chain

### DIFF
--- a/libraries/resource_ssl_certificate_chain.rb
+++ b/libraries/resource_ssl_certificate_chain.rb
@@ -57,6 +57,7 @@ class Chef
             data_bag
             chef_vault
             file
+            self_signed
           ).freeze
         end
 
@@ -191,6 +192,10 @@ class Chef
 
         def default_chain_content_from_file
           safe_read_from_path('SSL intermediary chain', chain_path)
+        end
+
+        def default_chain_content_from_self_signed
+          nil
         end
 
         def default_chain_content

--- a/libraries/resource_ssl_certificate_pkcs12.rb
+++ b/libraries/resource_ssl_certificate_pkcs12.rb
@@ -56,7 +56,11 @@ class Chef
         def generate_pkcs12
           key = OpenSSL::PKey.read(key_content)
           crt = OpenSSL::X509::Certificate.new(cert_content)
-          OpenSSL::PKCS12.create(pkcs12_passphrase, name, key, crt).to_der
+          chain = if chain_content
+                    [crt, OpenSSL::X509::Certificate.new(chain_content)]
+                  end
+          OpenSSL::PKCS12.create(pkcs12_passphrase,
+                                 name, key, crt, chain).to_der
         end
 
         def pkcs12_content


### PR DESCRIPTION
Add self-signed chain methods to ensure that CI passes.  Currently the self-signed chain simply returns `nil`; this could be enhanced later but works for now.