### PR TITLE
Add ability to redefine ssl_chain combined_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ When a namespace is set in the resource, it will try to read the following attri
 | `namespace['ssl_chain']['name']`                   | File name to be used for the intermediate certificate chain file. **If this is not present, no chain file will be written.**
 | `namespace['ssl_chain']['source']`                 | Source type to get the intermediate certificate chain from. Can be `'attribute'`, `'data-bag'`, `'chef-vault'` or `'file'`.
 | `namespace['ssl_chain']['path']`                   | File path of the intermediate SSL certificate chain.
+| `namespace['ssl_chain']['combined_path']`          | File path of the combined certificates (intermediate chain + domain certificate).
 | `namespace['ssl_chain']['bag']`                    | Name of the Data Bag where the intermediate certificate chain is stored.
 | `namespace['ssl_chain']['item']`                   | Name of the Data Bag Item where the intermediate certificate chain is stored.
 | `namespace['ssl_chain']['item_key']`               | Key of the Data Bag Item where the intermediate certificate chain is stored.

--- a/libraries/resource_ssl_certificate_chain.rb
+++ b/libraries/resource_ssl_certificate_chain.rb
@@ -208,8 +208,8 @@ class Chef
         end
 
         def default_chain_combined_path
-          lazy do
-            @default_chain_combined_path ||=
+          lazy_cached_variable(:default_chain_combined_path) do
+            read_namespace(%w(ssl_chain combined_path)) ||
               ::File.join(cert_dir, chain_combined_name)
           end
         end


### PR DESCRIPTION
### Description

There are possibility to redefine full path for the domain cert, key and intermediate chain file. But combined file (".chained.pem") path is hardcoded. So I added variable to redefine this path too.

### Contribution Check List

I did not added any tests because there are no tests at all to check custom paths.

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README and metadata if applicable.