### PR TITLE
Drop Ubuntu 10.04, 12.04, 15.04 from test suite

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -30,18 +30,6 @@ platforms:
     flavor: 512MB
   run_list: recipe[apt]
 
-- name: ubuntu-10-04-x64
-  driver_plugin: digitalocean
-  driver_config:
-    flavor: 512MB
-  run_list: recipe[apt]
-
-- name: ubuntu-12-04-x64
-  driver_plugin: digitalocean
-  driver_config:
-    flavor: 512MB
-  run_list: recipe[apt]
-
 - name: ubuntu-14-04-x64
   driver_plugin: digitalocean
   driver_config:

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -17,8 +17,6 @@ platforms:
 - name: oraclelinux-6
   driver_config:
     platform: rhel
-- name: ubuntu-12.04
-  run_list: recipe[apt]
 - name: ubuntu-14.04
   run_list: recipe[apt]
 - name: ubuntu-15.04

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -19,8 +19,6 @@ platforms:
     platform: rhel
 - name: ubuntu-14.04
   run_list: recipe[apt]
-- name: ubuntu-15.04
-  run_list: recipe[apt]
 # Requires AUFS with CONFIG_AUFS_XATTR support.
 # Issue https://github.com/docker/docker/issues/6980:
 # error: unpacking of archive failed on file /usr/sbin/suexec: cpio:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,10 +25,6 @@ platforms:
   run_list: [ "recipe[apt]" ]
 - name: fedora-20
 - name: fedora-21
-- name: ubuntu-10.04
-  run_list: [ "recipe[apt]" ]
-- name: ubuntu-12.04
-  run_list: [ "recipe[apt]" ]
 - name: ubuntu-14.04
   run_list: [ "recipe[apt]" ]
 - name: ubuntu-15.04
@@ -65,8 +61,6 @@ suites:
   - freebsd-10.0
   # TLS 1.2 not supported (modern compatibility)
   - debian-6
-  - ubuntu-10.04
-  - ubuntu-12.04
   data_bags_path: "test/data_bags"
   encrypted_data_bag_secret_key_path: "test/encrypted_data_bag_secret"
   run_list:
@@ -76,7 +70,6 @@ suites:
   # no TLSv1.1 support
   - centos-5.11
   - debian-6
-  - ubuntu-10.04
   # nginx cookbook not compatible
   - freebsd-10.0 # https://github.com/miketheman/nginx/issues/274
   - scientific-6.6

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,8 +27,6 @@ platforms:
 - name: fedora-21
 - name: ubuntu-14.04
   run_list: [ "recipe[apt]" ]
-- name: ubuntu-15.04
-  run_list: [ "recipe[apt]" ]
 
 suites:
 - name: default

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
   ruby:
     version: 2.4.0
   environment:
-    TESTS: (centos-6|debian-[67]) (debian-8|oraclelinux-6) ubuntu-1[24]04 (ubuntu-1504|scientific-6)
+    TESTS: (centos-6|debian-[67]) (debian-8|oraclelinux-6) ubuntu-1404 (ubuntu-1504|scientific-6)
     CHEF_VERSION: ~> 12.0
 
 dependencies:

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
   ruby:
     version: 2.4.0
   environment:
-    TESTS: (centos-6|debian-[67]) (debian-8|oraclelinux-6) ubuntu-1404 (ubuntu-1504|scientific-6)
+    TESTS: (centos-6|debian-[67]) (debian-8|oraclelinux-6) ubuntu-1404 scientific-6
     CHEF_VERSION: ~> 12.0
 
 dependencies:


### PR DESCRIPTION
### Description

Ubuntu `10.04` and `12.04` are End of Life and cause tests to fail when trying to run `apt-get`

https://www.ubuntu.com/info/release-end-of-life

### Issues Resolved

Make tests pass.

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README and metadata if applicable.

See [CONTRIBUTING.md](https://github.com/zuazo/ssl_certificate-cookbook/blob/master/CONTRIBUTING.md).
