### PR TITLE
Chef 13 - remove Fixnum deprecations

### DIFF
--- a/libraries/resource_ssl_certificate.rb
+++ b/libraries/resource_ssl_certificate.rb
@@ -115,7 +115,7 @@ class Chef
       def time(arg = nil)
         # ~ 10 years
         set_or_return(
-          :time, arg, kind_of: [Fixnum, String, Time], default: 315_360_000
+          :time, arg, kind_of: [Integer, String, Time], default: 315_360_000
         )
       end
 

--- a/libraries/resource_ssl_certificate_keycert.rb
+++ b/libraries/resource_ssl_certificate_keycert.rb
@@ -34,7 +34,7 @@ class Chef
       module KeyCert
         def years(arg = nil)
           return (time.to_i / 31_536_000).round if arg.nil?
-          unless [Fixnum, String].inject(false) { |a, e| a || arg.is_a?(e) }
+          unless [Integer, String].inject(false) { |a, e| a || arg.is_a?(e) }
             raise Exceptions::ValidationFailed,
                   "Option years must be a kind of #{to_be}! You passed "\
                   "#{arg.inspect}."

--- a/test/cookbooks/ssl_certificate_test/metadata.rb
+++ b/test/cookbooks/ssl_certificate_test/metadata.rb
@@ -30,6 +30,6 @@ EOS
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
-depends 'nginx', '~> 2.7'
+depends 'nginx', '~> 7.0'
 depends 'apache2', '~> 3.0'
 depends 'ssl_certificate'

--- a/test/unit/recipes/nginx_spec.rb
+++ b/test/unit/recipes/nginx_spec.rb
@@ -46,7 +46,7 @@ describe 'ssl_certificate_test::nginx', order: :random do
       .with_group('root')
   end
 
-  it 'enables nginx virtualhost' do
-    expect(chef_run).to run_execute('nxensite ssl_certificate')
+  it 'enables the nginx virtualhost' do
+    expect(chef_run).to enable_nginx_site('ssl_certificate')
   end
 end


### PR DESCRIPTION
- Switch Fixnum to Integer to handle the Ruby 2.4 removal of Fixnum/Bignum for Chef 13+

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README and metadata if applicable.

See [CONTRIBUTING.md](https://github.com/zuazo/ssl_certificate-cookbook/blob/master/CONTRIBUTING.md).
