### PR TITLE
Only create_chain_combined when namespace['ssl_chain']['name'] is defined

### DIFF
--- a/libraries/provider_ssl_certificate.rb
+++ b/libraries/provider_ssl_certificate.rb
@@ -126,7 +126,7 @@ class Chef
         create_key
         create_cert
         create_pkcs12 if create_pkcs12?
-        create_chain_combined
+        create_chain_combined if create_chain?
         create_chain if create_chain?
       end
     end


### PR DESCRIPTION


### Description

The intermediary chain combined filed is always created, even if namespace['ssl_chain']['name'] is nil.

### Issues Resolved

#38

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README and metadata if applicable.

See [CONTRIBUTING.md](https://github.com/zuazo/ssl_certificate-cookbook/blob/master/CONTRIBUTING.md).
