### PR TITLE
Specify the resource provider for ssl_certificate

### DIFF
--- a/libraries/resource_ssl_certificate.rb
+++ b/libraries/resource_ssl_certificate.rb
@@ -58,6 +58,8 @@ class Chef
       # Include methods related to PKCS12 attributes.
       include ::Chef::Resource::SslCertificate::PKCS12
 
+      provides :ssl_certificate
+
       def initialize(name, run_context = nil)
         super
         @resource_name = :ssl_certificate


### PR DESCRIPTION
### Description

In Chef 16 HWRP Style Resources now require resource_name / provides ([source](https://docs.chef.io/release_notes/#hwrp-style-resources-now-require-resource_name--provides)). Without this, Chef fails to compile and provides the following error:

```
       NoMethodError
       -------------
       undefined method `ssl_certificate' for cookbook: child-cookbook, recipe: default :Chef::Recipe
```

This PR sets the provider and stops Chef from crashing.

### Issues Resolved

#45 

### Contribution Check List

* Do the tests pass
  * The CentOS Kitchen tests (I tried with CentOS 6 as per the current kitchen.yml and also CentOS 7.8 as this is what the ticket was raised for) all pass.
  * The Kitchen tests for the other platforms are failing, but this is because they're using out dated operating systems e.g. the Ubuntu 10.04 tests are getting 404s trying to get package lists. I tried running with Ubuntu 20.04, but the tests need updating because the output of openssl has changed. Unfortunately I've run out of time so haven't been able to fix them, but I can't see any evidence that the change I have made has caused issues.
  * I  checked the CentOS kitchen tests work with both Chef 16 and Chef 14
* New functionality includes testing.
  * Not applicable
* New functionality has been documented in the README and metadata if applicable.
  * Not applicable
